### PR TITLE
Add CI for build and testing

### DIFF
--- a/.github/workflows/scala.yaml
+++ b/.github/workflows/scala.yaml
@@ -16,12 +16,11 @@ jobs:
       with:
           fetch-depth: 0
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v4
+    - name: Setup Scala
+      uses: coursier/setup-action@v1
       with:
-        java-version: '11'
-        distribution: 'adopt'
-        cache: 'sbt'
+        jvm: adopt:11
+        apps: sbt
 
     - name: Run compile
       run: sbt clean compile
@@ -51,6 +50,12 @@ jobs:
           with:
             fetch-depth: 0
             ref: ${{ github.event.pull_request.head.sha }}
+
+        - name: Setup Scala
+          uses: coursier/setup-action@v1
+          with:
+            jvm: adopt:11
+            apps: sbt
 
         - name: Run tests
           run: sbt clean coverage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: scala
-scala:
-  - 3.3.1
-jdk:
-  - openjdk11
-
-script:
-  - sbt clean compile test 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Coverage Status](https://coveralls.io/repos/github/fadismoqyS/colorwoodSort-25/badge.svg?branch=ci-cd)](https://coveralls.io/github/fadismoqyS/colorwoodSort-25?branch=ci-cd)
+
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/aaa02e74a4d2496f8fbb89af0d26213c)](https://app.codacy.com/gh/fadismoqyS/colorwoodSort-25/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+
 ## sbt project compiled with Scala 3
 
 ### Usage
@@ -8,3 +12,4 @@ For more information on the sbt-dotty plugin, see the
 [scala3-example-project](https://github.com/scala/scala3-example-project/blob/main/README.md).
 
 [![Build Status](https://travis-ci.com/fadismoqyS/colorwoodSort-25.svg?branch=master)](https://travis-ci.com/fadismoqyS/colorwoodSort-25)
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val scala3Version = "3.3.1"
+val scala3Version = "3.5.1"
 
 lazy val root = project
   .in(file("."))
@@ -10,10 +10,5 @@ lazy val root = project
       "org.scalactic" %% "scalactic" % "3.2.14",
       "org.scalatest" %% "scalatest" % "3.2.14" % Test
     ),
-    testFrameworks += new TestFramework("org.scalatest.tools.Framework"),
-    coverageEnabled := true,
-    coverageFailOnMinimum := false,
-    coverageHighlighting := true,
-    coverageMinimumStmtTotal := 60,
-    coverageMinimumBranchTotal := 60
+    
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.12")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.1")


### PR DESCRIPTION
This pull request removes the `.travis.yml` configuration file, effectively discontinuing the use of Travis CI for continuous integration in the project.

Continuous integration deprecation:

* [`.travis.yml`](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L1-L8): Removed Scala language specification, JDK version, and build/test script, signaling the project's shift away from Travis CI.